### PR TITLE
Ticker Scroll Animation and updateRefreshInterval

### DIFF
--- a/MMM-MyScoreboard.css
+++ b/MMM-MyScoreboard.css
@@ -1076,3 +1076,29 @@
   from {opacity: .1} 
   to {opacity: 1}
 }
+
+/* Scroll Animation */
+
+.MMM-MyScoreboard .wrapper {
+  max-height: var(--max-height);
+  overflow: hidden;
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.MMM-MyScoreboard .scroll-container {
+  animation: scroll var(--animation-duration) linear infinite;
+}
+
+.MMM-MyScoreboard .wrapper.running .scroll-container {
+  animation-play-state: running !important;
+}
+
+.MMM-MyScoreboard .wrapper.paused .scroll-container {
+  animation-play-state: paused !important;
+}
+
+@keyframes scroll {
+  0% { transform: translate3d(0, 0, 0); }
+  100% { transform: translate3d(0, calc(-100% - 10px), 0); }
+}

--- a/MMM-MyScoreboard.css
+++ b/MMM-MyScoreboard.css
@@ -1079,26 +1079,23 @@
 
 /* Scroll Animation */
 
-.MMM-MyScoreboard .wrapper {
-  max-height: var(--max-height);
+.MMM-MyScoreboard .wrapper.scroll {
   overflow: hidden;
   display: inline-block;
   white-space: nowrap;
 }
 
-.MMM-MyScoreboard .scroll-container {
-  animation: scroll var(--animation-duration) linear infinite;
-}
-
-.MMM-MyScoreboard .wrapper.running .scroll-container {
+.MMM-MyScoreboard .wrapper.scroll .scroll-container {
+  animation: scroll linear infinite;
+  will-change: transform;
   animation-play-state: running !important;
 }
 
-.MMM-MyScoreboard .wrapper.paused .scroll-container {
-  animation-play-state: paused !important;
-}
-
 @keyframes scroll {
-  0% { transform: translate3d(0, 0, 0); }
-  100% { transform: translate3d(0, calc(-100% - 10px), 0); }
+  from { 
+    transform: translateY(10px);
+  }
+  to {
+    transform: translateY(-100%);
+  };
 }

--- a/MMM-MyScoreboard.js
+++ b/MMM-MyScoreboard.js
@@ -370,7 +370,7 @@
    setupScrollAnimation: function (wrapper, lines) {
     // Pull the wrapper height as it is built. If it is greater than scrollAnimation.height, trigger animation
     const domHeight = document.querySelector('.MMM-MyScoreboard .wrapper').scrollHeight,
-      shouldAnimate = this.config.scrollAnimation.scroll && this.config.scrollAnimation.height < domHeight + 10; // Add 10px for margin-top
+      shouldAnimate = this.config.scrollAnimation.scroll && this.config.scrollAnimation.height < domHeight;
     let container = null,
       clone = null;
 

--- a/MMM-MyScoreboard.js
+++ b/MMM-MyScoreboard.js
@@ -1,4 +1,4 @@
-/*********************************
+ /*********************************
 
  MagicMirror² Module:
  MMM-MyScoreboard
@@ -10,7 +10,7 @@
 
  *********************************/
 
-Module.register('MMM-MyScoreboard', {
+ Module.register('MMM-MyScoreboard', {
 
   // Default module config.
   defaults: {
@@ -28,9 +28,9 @@ Module.register('MMM-MyScoreboard', {
     localMarkets: [],
     displayLocalChannels: [],
     channelRotateInterval: 7000,
-    animation: { 
+    scrollAnimation: {
       scroll: false,
-      scrollSpeed: 6, 
+      scrollSpeed: 6,
       height: 10000
     },
     // limitBroadcasts: 1,
@@ -366,19 +366,21 @@ Module.register('MMM-MyScoreboard', {
    </div>
    ******************************************************************/
 
-   // New Scroll Animation Function 
-   setupScrollAnimation: function(wrapper, lines) {
-    // Pull the wrapper height as it is built. If it is greater than animation.height, trigger animation
-    domHeight = document.querySelector('.MMM-MyScoreboard .wrapper').scrollHeight; 
-    const shouldAnimate = this.config.animation.scroll && this.config.animation.height < domHeight + 10; // Add 10px for margin-top
-    let [container, clone] = [null, null];
+   // New Scroll Animation Function
+   setupScrollAnimation: function (wrapper, lines) {
+    // Pull the wrapper height as it is built. If it is greater than scrollAnimation.height, trigger animation
+    const domHeight = document.querySelector('.MMM-MyScoreboard .wrapper').scrollHeight,
+      shouldAnimate = this.config.scrollAnimation.scroll && this.config.scrollAnimation.height < domHeight + 10; // Add 10px for margin-top
+    let container = null,
+      clone = null;
+
     wrapper.classList.remove('running', 'paused'); // Remove animation classes temporarily
     if (!shouldAnimate) {
       wrapper.classList.add('paused');
       return;
     }
     // Create new containers if they don't exist
-    if (!container) { 
+    if (!container) {
       container = document.createElement('div');
       container.className = 'scroll-container';
       wrapper.appendChild(container);
@@ -393,7 +395,7 @@ Module.register('MMM-MyScoreboard', {
       container.appendChild(node);
       clone.appendChild(node.cloneNode(true));
     }
-    const animationDuration = this.config.animation.scrollSpeed * lines; // Calculate dynamic duration based on content height
+    const animationDuration = this.config.scrollAnimation.scrollSpeed * lines; // Calculate dynamic duration based on content height
     wrapper.style.setProperty('--animation-duration', `${animationDuration}s`);
     wrapper.classList.add('running'); // Start animation
   },
@@ -628,8 +630,8 @@ Module.register('MMM-MyScoreboard', {
     }
 
     // New property to set wrapper height
-    if (this.config.animation.height) {
-      wrapper.style.setProperty('--max-height', `${this.config.animation.height}px`);
+    if (this.config.scrollAnimation.height) {
+      wrapper.style.setProperty('--max-height', `${this.config.scrollAnimation.height}px`);
     }
     /*
       Show "Loading" when there's no data initially.
@@ -648,7 +650,7 @@ Module.register('MMM-MyScoreboard', {
     */
     // var anyGames = false
     var self = this
-    var lines = 0; // Calculate number of lines for animation duration
+    let lines = 0; // Calculate number of lines for animation duration
     this.config.sports.forEach(function (sport) {
       var leagueSeparator = []
       if (self.sportsData[sport.league] != null && self.sportsData[sport.league].length > 0) {
@@ -729,22 +731,22 @@ Module.register('MMM-MyScoreboard', {
     });
     return lines;
   },
-  
-  // New setInterval Logic to match the animation speed. Minimum 2 minutes. 
+
+  // New setInterval Logic to match the animation speed. Minimum 2 minutes.
   // Calculates a multiple of the animationDuration so it updates when animation has completed the lap.
-  // Unfortunately, there is no other way to have a smooth transition because it always rebuilds the DOM and starts at 0. 
+  // Unfortunately, there is no other way to have a smooth transition because it always rebuilds the DOM and starts at 0.
   // If we could update the innerHTML only, then it wouldn't have a harsh reset.
-  updateRefreshInterval: function() {
+  updateRefreshInterval: function () {
   let refreshInterval;
   const minRefresh = 2 * 60 * 1000; // 2 minutes in milliseconds
   refreshInterval = minRefresh;
 
-  if (this.config.animation.scroll) {
-    const lines = this.calculateTotalLines();
+  if (this.config.scrollAnimation.scroll) {
+    var lines = this.calculateTotalLines();
     if (lines > 0) {
-      const animationDuration = this.config.animation.scrollSpeed * lines;
-      const animationDurationMs = animationDuration * 1000;
-      const calculatedInterval = Math.ceil(minRefresh / animationDurationMs) * animationDurationMs;
+      const animationDuration = this.config.scrollAnimation.scrollSpeed * lines,
+        animationDurationMs = animationDuration * 1000,
+        calculatedInterval = Math.ceil(minRefresh / animationDurationMs) * animationDurationMs;
       refreshInterval = Math.max(minRefresh, calculatedInterval);
     }
   }

--- a/MMM-MyScoreboard.js
+++ b/MMM-MyScoreboard.js
@@ -737,26 +737,26 @@
   // Unfortunately, there is no other way to have a smooth transition because it always rebuilds the DOM and starts at 0.
   // If we could update the innerHTML only, then it wouldn't have a harsh reset.
   updateRefreshInterval: function () {
-  let refreshInterval;
+  let currentRefresh;
   const minRefresh = 2 * 60 * 1000; // 2 minutes in milliseconds
-  refreshInterval = minRefresh;
+  currentRefresh = minRefresh;
 
   if (this.config.scrollAnimation.scroll) {
     if (this.totalDivs > 0) {
       const animationDuration = this.config.scrollAnimation.scrollSpeed * this.totalDivs,
         animationDurationMs = animationDuration * 1000,
         calculatedInterval = Math.ceil(minRefresh / animationDurationMs) * animationDurationMs;
-      refreshInterval = Math.max(minRefresh, calculatedInterval);
+      currentRefresh = Math.max(minRefresh, calculatedInterval);
     }
   }
   // currentIntervalDuration starts as 0 so it always runs the first time (0 !== 120000)
-  if (refreshInterval !== this.currentIntervalDuration) {
+  if (currentRefresh !== this.refreshInterval) {
     if (this.refreshIntervalId) clearInterval(this.refreshIntervalId);
     var self = this
     this.refreshIntervalId = setInterval(() => {
       self.getScores();
-      }, refreshInterval);
-    this.currentIntervalDuration = refreshInterval;
+      }, currentRefresh);
+    this.refreshInterval = currentRefresh;
   }
 },
 

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ Add MMM-MyScoreboard module to the `modules` array in the `config/config.js` fil
 | `displayLocalChannels` | A list of local channels you would like to display, even if `showLocalBroadcasts` is set to `false`.  This allows you to manually set the local broadcast channels you receive.  I.e., start with no channels and add the ones you want.  `displayLocalChannels` will override any other option to turn off channels.<br><br>**Type** `Array` or `Strings`<br>**Default** `[]`
 | `scrollAnimation`      | Control the scrolling ticker animation. See below for configuration.<br><br>**Type** `Object`
 
-### Configuring "scrollAnimation"
+### Configuring "Scrolling Animation"
 
 | Property      | Description
 |---------------|------------
 | `scroll`      | Enable animation for ticker effect.<br><br>**Type** `Boolean`<br>**Default** `false`
-| `height`      | Limit the height of the container.<br><br>**Type** `Number`<br>**Default** `10000` ensures all items are shown unless restricted
-| `scrollSpeed` | Number of seconds each line should take to traverse to the next line. `1` = very fast. `10` = very slow. For example, your `height` might be `300` and display 10 box scores. `scrollSpeed` of `6` will take 60 seconds for the bottom score to reach the top.<br><br>**Type** `Number`<br>**Default** `6`
+| `height`      | Limit the height of the container. For best results, set the limit to show exactly the number of games you want when static. This ensures that any extra games will be fully hidden and force the animation to start. No animation will occur if there are fewer games than fill the container.<br><br>**Type** `Number`<br>**Default** `10000` ensures all games are shown unless restricted
+| `scrollSpeed` | Number of seconds each line should take to traverse to the next one. `1` = very fast. `10` = very slow. For example, your `height` might be `300` and display 10 games & league-separators. `scrollSpeed` of `6` will take 60 seconds for the last visible game/separator to reach the top.<br><br>**Type** `Number`<br>**Default** `6`
 
 
 ### Configuring Your "Sports" List

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Add MMM-MyScoreboard module to the `modules` array in the `config/config.js` fil
 |---------------|------------
 | `scroll`      | Enable animation for ticker effect.<br><br>**Type** `Boolean`<br>**Default** `false`
 | `height`      | Limit the height of the container.<br><br>**Type** `Number`<br>**Default** `10000` ensures all items are shown unless restricted
-| `scrollSpeed` | Number of seconds each line should take to traverse to the next line. `1` = very fast. `10` = very slow. For example, your `height` might be `300` and display `10` box scores. `scrollSpeed` of `6` will take 60 seconds for the bottom score to reach the top.<br><br>**Type** `Number`<br>**Defualt** `6`
+| `scrollSpeed` | Number of seconds each line should take to traverse to the next line. `1` = very fast. `10` = very slow. For example, your `height` might be `300` and display 10 box scores. `scrollSpeed` of `6` will take 60 seconds for the bottom score to reach the top.<br><br>**Type** `Number`<br>**Default** `6`
 
 
 ### Configuring Your "Sports" List

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ Add MMM-MyScoreboard module to the `modules` array in the `config/config.js` fil
 |---------------|------------
 | `scroll`      | Enable animation for ticker effect.<br><br>**Type** `Boolean`<br>**Default** `false`
 | `height`      | Limit the height of the container. For best results, set the limit to show exactly the number of games you want when static. This ensures that any extra games will be fully hidden and force the animation to start. No animation will occur if there are fewer games than fill the container.<br><br>**Type** `Number`<br>**Default** `10000` ensures all games are shown unless restricted
-| `scrollSpeed` | Number of seconds each line should take to traverse to the next one. `1` = very fast. `10` = very slow. For example, your `height` might be `300` and display 10 games & league-separators. `scrollSpeed` of `6` will take 60 seconds for the last visible game/separator to reach the top.<br><br>**Type** `Number`<br>**Default** `6`
-
+| `scrollSpeed` | Rate for scrolling. `3` = fast, `10` = slow.<br><br>**Type** `Number`<br>**Default** `6`
 
 ### Configuring Your "Sports" List
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ Add MMM-MyScoreboard module to the `modules` array in the `config/config.js` fil
 | `localMarkets`         | A list of your local markets so that you can display only broadcast stations from your local market.  Use the team abbreviations for any teams in your local broadcast market.  For example, if you live in Los Angeles, you may want to use `['ANA', 'LA', 'LAA', 'LAD', 'LAC', 'LAL', 'LAR', 'LAFC', 'UCLA', 'USC']` (note: 'LAC' will pick up both the Chargers and the Clippers). If you live in Miami, you may only need `['MIA']`.<br><br>**Type** `Array` of `Strings`<br>**Default** `[]`
 | `skipChannels`         | A list of channels that you would never like to see displayed (e.g., if you do not subscribe to that channel).  You can find the abbreviation for a channel that displays as a logo by checking `MMM-MyScoreboard/providers/ESPN.js`.  I.e., start with all the channels and remove the ones you don't want.  `skipChannels` will override any other option to display certain channels.<br><br>**Type** `Array` of `Strings`<br>**Default** `[]`
 | `displayLocalChannels` | A list of local channels you would like to display, even if `showLocalBroadcasts` is set to `false`.  This allows you to manually set the local broadcast channels you receive.  I.e., start with no channels and add the ones you want.  `displayLocalChannels` will override any other option to turn off channels.<br><br>**Type** `Array` or `Strings`<br>**Default** `[]`
+| `scrollAnimation`      | Control the scrolling ticker animation. See below for configuration.<br><br>**Type** `Object`
+
+### Configuring "scrollAnimation"
+
+| Property      | Description
+|---------------|------------
+| `scroll`      | Enable animation for ticker effect.<br><br>**Type** `Boolean`<br>**Default** `false`
+| `height`      | Limit the height of the container.<br><br>**Type** `Number`<br>**Default** `10000` ensures all items are shown unless restricted
+| `scrollSpeed` | Number of seconds each line should take to traverse to the next line. `1` = very fast. `10` = very slow. For example, your `height` might be `300` and display `10` box scores. `scrollSpeed` of `6` will take 60 seconds for the bottom score to reach the top.<br><br>**Type** `Number`<br>**Defualt** `6`
 
 
 ### Configuring Your "Sports" List

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-myscoreboard",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-myscoreboard",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "license": "MIT",
       "dependencies": {
         "moment-timezone": "^0.5.48"
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-      "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
+      "integrity": "sha512-RI17tsD2frtDu/3dmI7QRrD4bedNKPM08ziRYaC5AhkGrzIAJelm9kJU1TznK+apx6V+cqRz8tfpEeG3oIyjxw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
-      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
+      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -204,13 +204,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -651,6 +651,18 @@
         }
       }
     },
+    "node_modules/eslint-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin/-/eslint-plugin-1.0.1.tgz",
+      "integrity": "sha512-ervp8C09On0fLA258TvE08AqAr/bhRYgHVZd3BrJjD4JfOA2JGANDLGs06j51oWqfPd7Feoo3OoqHD+fuI2sFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
@@ -679,6 +691,29 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
+      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -1391,6 +1426,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.5"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-myscoreboard",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "A MagicMirror² module to display scores for your favorite teams from many major sports.",
   "repository": {
     "type": "git",
@@ -34,8 +34,9 @@
   "author": "Jeff Clarke",
   "contributors": [
     "Jeff Clarke",
-    "dathbe"
-  ],  
+    "dathbe",
+    "mikeyounge"
+  ],
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
@@ -43,10 +44,11 @@
   },
   "license": "MIT",
   "dependencies": {
+    "eslint-plugin": "^1.0.1",
     "moment-timezone": "^0.5.48"
   },
   "devDependencies": {
-    "@eslint/js": "^9.24.0",
+    "@eslint/js": "^9.23.0",
     "@stylistic/eslint-plugin": "^4.2.0",
     "eslint": "^9.24.0",
     "globals": "^16.0.0"


### PR DESCRIPTION
New Animation config. Default to off and display the whole wrapper. 
Set height to maximum that is displayed (starts at value that allows for any size). Overflow will be hidden unless scroll is true. 
scrollSpeed is seconds per line. 6 = 10 lines shown over 60 seconds. 1 = 10 lines shown over 10 seconds (very fast). In it's current configuration, there can be a slight delay if animation.height is close to the total height of the wrapper It may take a refresh for it to catch up and start animating. Uses the total height of the wrapper as queried by the document. If you know a better way, please feel free to re-work it. 

Created a new refresh function to have the refresh match up with the scroll rate. There is a minimum of 2 minutes, but for the animation to not be glitchy, the refresh needs to match when the scrollTop is back to 0. It calculates a multiple of the animationDuration and refreshes at the soonest point after the minimum wait time. e.g 11 lines at 6 seconds is 66 seconds per lap. Update interval is 132 seconds (2x 66sec).

#55 