### PR TITLE
Fix games near midnight ET disappearing for non-Eastern viewers (#210)

### DIFF
--- a/providers/ESPN.js
+++ b/providers/ESPN.js
@@ -575,20 +575,19 @@ module.exports = {
     return this.LEAGUE_PATHS[league]
   },
 
-  async getScores(payload, gameDate, callback) {
-    var self = this
-
+  /*
+    Build the ESPN scoreboard URL for a single YYYYMMDD date string.
+  */
+  scoreboardUrl: function (league, dateStr) {
     var url = 'https://site.web.api.espn.com/apis/site/v2/sports/'
-    url += this.getLeaguePath(payload.league)
-    if (this.getLeaguePath(payload.league).includes('scorepanel')) {
+    url += this.getLeaguePath(league)
+    if (this.getLeaguePath(league).includes('scorepanel')) {
       url += '?dates='
     }
     else {
       url += '/scoreboard?dates='
     }
-    url += moment(gameDate).format('YYYYMMDD') + '&limit=200'
-    var MLBurl = 'https://mastapi.mobile.mlbinfra.com/api/epg/v3/search?date='
-      + moment().add(payload.debugHours, 'hours').add(payload.debugMinutes, 'minutes').format('YYYY-MM-DD') + '&exp=MLB'
+    url += dateStr + '&limit=200'
     /*
       by default, ESPN returns only the Top 25 ranked teams for NCAAF
       and NCAAM. By appending the group parameter (80 for NCAAF and 50
@@ -599,20 +598,80 @@ module.exports = {
       currently have things set up, I need to treat it like a different
       league.
     */
-    if (payload.league == 'NCAAF') {
+    if (league == 'NCAAF') {
       url = url + '&groups=80'
     }
-    else if (payload.league == 'NCAAM') {
+    else if (league == 'NCAAM') {
       url = url + '&groups=50'
     }
-    else if (payload.league == 'NCAAM_MM') {
+    else if (league == 'NCAAM_MM') {
       url = url + '&groups=100'
     }
+    return url
+  },
+
+  /*
+    Fetch one ESPN scoreboard day and return a body normalized to { events: [] }.
+    The scorepanel feed (rugby) nests events under a `scores` array; flatten it
+    so callers always see a plain events list.
+  */
+  async fetchScoreboardEvents(league, dateStr) {
+    var url = this.scoreboardUrl(league, dateStr)
+    const response = await fetch(url)
+    Log.debug(`[MMM-MyScoreboard] ${url} fetched`)
+    var body = await response.json()
+
+    if (this.getLeaguePath(league).includes('scorepanel')) {
+      var flattened = { events: [] }
+      for (let leagueIdx = 0; leagueIdx < body['scores'].length; leagueIdx++) {
+        flattened['events'] = flattened['events'].concat(body['scores'][leagueIdx]['events'])
+      }
+      body = flattened
+    }
+    if (!body.events) {
+      body.events = []
+    }
+    return body
+  },
+
+  /*
+    ESPN buckets games by US Eastern calendar date, but formatScores() filters
+    the returned events by the *viewer's local* calendar date. A game that
+    kicks off near midnight ET can therefore land on a different local day than
+    the ET day ESPN filed it under — so it would be returned by neither the
+    "today" nor the "yesterday" query and silently disappear (issue #210: a
+    World Cup match at 02:00 UTC shows under ESPN's previous day, but is "today"
+    for a European viewer).
+
+    Return the single adjacent ESPN date that must also be fetched so the local
+    filter can recover such games. Viewers east of ET see games on the same or
+    next local day (so also pull the previous ET day); viewers west of ET see
+    them on the same or previous local day (so also pull the next ET day).
+    Returns null when the viewer is on Eastern time (no skew possible).
+  */
+  neighborGameDate: function (dateStr) {
+    var localTZ = moment.tz.guess()
+    var ref = moment(dateStr, 'YYYYMMDD')
+    var localOffset = moment.tz(ref, localTZ).utcOffset()
+    var easternOffset = moment.tz(ref, 'America/New_York').utcOffset()
+    if (localOffset > easternOffset) {
+      return moment(ref).subtract(1, 'day').format('YYYYMMDD') // east of ET
+    }
+    if (localOffset < easternOffset) {
+      return moment(ref).add(1, 'day').format('YYYYMMDD') // west of ET
+    }
+    return null
+  },
+
+  async getScores(payload, gameDate, callback) {
+    var self = this
+
+    var primaryDate = moment(gameDate).format('YYYYMMDD')
+    var MLBurl = 'https://mastapi.mobile.mlbinfra.com/api/epg/v3/search?date='
+      + moment().add(payload.debugHours, 'hours').add(payload.debugMinutes, 'minutes').format('YYYY-MM-DD') + '&exp=MLB'
 
     try {
-      const response = await fetch(url)
-      Log.debug(`[MMM-MyScoreboard] ${url} fetched`)
-      var body = await response.json()
+      var body = await this.fetchScoreboardEvents(payload.league, primaryDate)
 
       if (this.freeGameOfTheDay['day'] !== moment(gameDate).format('YYYY-MM-DD') && payload.league === 'MLB' && !payload.hideBroadcasts) {
         const freeGameResponse = await fetch(MLBurl)
@@ -632,19 +691,36 @@ module.exports = {
         }
       }
 
-      if (this.getLeaguePath(payload.league).includes('scorepanel')) {
-        var body2 = { events: [] }
-        for (let leagueIdx = 0; leagueIdx < body['scores'].length; leagueIdx++) {
-          body2['events'] = body2['events'].concat(body['scores'][leagueIdx]['events'])
+      /*
+        Timezone widening (issue #210): also pull the adjacent ESPN day so games
+        ESPN filed under a neighboring US-Eastern date — but which fall on the
+        requested LOCAL date — survive the local-date filter in formatScores().
+        Events are deduped by id; ESPN's date buckets are disjoint, so this only
+        adds the boundary games.
+      */
+      var neighborDate = this.neighborGameDate(primaryDate)
+      if (neighborDate) {
+        try {
+          var neighborBody = await this.fetchScoreboardEvents(payload.league, neighborDate)
+          var seenIds = new Set(body.events.map(function (e) {
+            return e.id
+          }))
+          neighborBody.events.forEach(function (e) {
+            if (!seenIds.has(e.id)) {
+              body.events.push(e)
+            }
+          })
         }
-        body = body2
+        catch (neighborError) {
+          Log.error(`[MMM-MyScoreboard] neighbor day fetch failed: ${neighborError}`)
+        }
       }
 
       this.noGamesToday = false
-      callback(self.formatScores(payload, body, moment(gameDate).format('YYYYMMDD')), payload.index, this.noGamesToday)
+      callback(self.formatScores(payload, body, primaryDate), payload.index, this.noGamesToday)
     }
     catch (error) {
-      Log.error(`[MMM-MyScoreboard] ${error} ${url}`)
+      Log.error(`[MMM-MyScoreboard] ${error} ${this.scoreboardUrl(payload.league, primaryDate)}`)
     }
   },
 

--- a/tests/unit/providers/ESPN.timezone.test.js
+++ b/tests/unit/providers/ESPN.timezone.test.js
@@ -1,0 +1,160 @@
+'use strict'
+
+/*
+  Regression test for issue #210 — "World Cup Game missing".
+
+  ESPN buckets games by US Eastern calendar date, but formatScores() filters
+  the returned events by the *viewer's local* calendar date. A match kicking
+  off at 02:00 UTC is filed by ESPN under the previous (Eastern) day, yet for a
+  European viewer it falls on the current local day. Before the fix it was
+  returned by neither the "today" nor the "yesterday" query and disappeared.
+
+  These tests pin the local timezone (moment.tz.guess) so the behaviour is
+  deterministic regardless of the machine running them.
+*/
+
+const { describe, it, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const moment = require('moment-timezone')
+const ESPN = require(path.resolve(__dirname, '../../../providers/ESPN.js'))
+const { mockFetch } = require('../../helpers/mock-fetch')
+
+const SB = 'https://site.web.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard?dates='
+
+// Minimal soccer competitor / event shapes that formatScores() reads.
+function competitor(abbr, homeAway, score) {
+  return {
+    homeAway: homeAway,
+    score: score,
+    team: {
+      abbreviation: abbr,
+      name: abbr,
+      shortDisplayName: abbr,
+      displayName: abbr,
+      logo: '',
+    },
+  }
+}
+
+function soccerFinal(id, isoDate, home, away, hScore, vScore) {
+  return {
+    id: id,
+    date: isoDate,
+    competitions: [{
+      date: isoDate,
+      broadcasts: [],
+      competitors: [
+        competitor(home, 'home', hScore),
+        competitor(away, 'away', vScore),
+      ],
+    }],
+    status: { type: { id: '28', shortDetail: 'FT', detail: 'Full Time', description: 'Full Time' } },
+  }
+}
+
+const payload = {
+  league: 'FIFA_WORLD_CUP',
+  index: 0,
+  teams: null, // all games
+  hideBroadcasts: true,
+  skipChannels: [],
+  localMarkets: [],
+  displayLocalChannels: [],
+  showLocalBroadcasts: false,
+  debugHours: 0,
+  debugMinutes: 0,
+}
+
+describe('ESPN.getScores timezone widening (issue #210)', () => {
+  let mock
+  let origGuess
+
+  beforeEach(() => {
+    mock = mockFetch()
+    origGuess = moment.tz.guess
+    // Pretend the viewer is in central Europe (UTC+2 in June, east of ET).
+    moment.tz.guess = () => 'Europe/Berlin'
+  })
+
+  afterEach(() => {
+    mock.restore()
+    moment.tz.guess = origGuess
+  })
+
+  it('keeps a 02:00Z match that ESPN files under the previous Eastern day', async () => {
+    // "Today" for the European viewer is 2026-06-12.
+    // ESPN files the Korea match (02:00Z = 22:00 ET on the 11th) under June 11.
+    mock.route(SB + '20260612&limit=200', {
+      events: [soccerFinal('today', '2026-06-12T19:00Z', 'CAN', 'BIH', 1, 0)],
+    })
+    mock.route(SB + '20260611&limit=200', {
+      events: [
+        soccerFinal('mexopen', '2026-06-11T19:00Z', 'MEX', 'RSA', 2, 1),
+        soccerFinal('korea', '2026-06-12T02:00Z', 'KOR', 'CZE', 3, 1),
+      ],
+    })
+
+    let scores = null
+    await ESPN.getScores(payload, moment('20260612', 'YYYYMMDD'), (s) => {
+      scores = s
+    })
+
+    const matchups = scores.map(g => `${g.vTeam}@${g.hTeam}`)
+    // The Korea match (local June 12) is recovered from the neighbor day...
+    assert.ok(matchups.includes('CZE@KOR'), `expected CZE@KOR, got ${JSON.stringify(matchups)}`)
+    // ...alongside the genuinely-June-12 match...
+    assert.ok(matchups.includes('BIH@CAN'))
+    // ...but the June 11 evening match stays out of "today".
+    assert.ok(!matchups.includes('RSA@MEX'))
+  })
+
+  it('does not duplicate the boundary match into the previous day', async () => {
+    // "Yesterday" query for the same viewer is 2026-06-11.
+    mock.route(SB + '20260611&limit=200', {
+      events: [
+        soccerFinal('mexopen', '2026-06-11T19:00Z', 'MEX', 'RSA', 2, 1),
+        soccerFinal('korea', '2026-06-12T02:00Z', 'KOR', 'CZE', 3, 1),
+      ],
+    })
+    mock.route(SB + '20260610&limit=200', { events: [] })
+
+    let scores = null
+    await ESPN.getScores(payload, moment('20260611', 'YYYYMMDD'), (s) => {
+      scores = s
+    })
+
+    const matchups = scores.map(g => `${g.vTeam}@${g.hTeam}`)
+    // June 11 local day keeps only the evening opener...
+    assert.ok(matchups.includes('RSA@MEX'))
+    // ...and the 02:00Z match belongs to June 12, not here (no double-show).
+    assert.ok(!matchups.includes('CZE@KOR'), `Korea match should not appear on June 11, got ${JSON.stringify(matchups)}`)
+  })
+})
+
+describe('ESPN.neighborGameDate', () => {
+  let origGuess
+
+  afterEach(() => {
+    if (origGuess) moment.tz.guess = origGuess
+  })
+
+  it('east of Eastern (Europe) pulls the previous day', () => {
+    origGuess = moment.tz.guess
+    moment.tz.guess = () => 'Europe/Berlin'
+    assert.equal(ESPN.neighborGameDate('20260612'), '20260611')
+  })
+
+  it('west of Eastern (Pacific) pulls the next day', () => {
+    origGuess = moment.tz.guess
+    moment.tz.guess = () => 'America/Los_Angeles'
+    assert.equal(ESPN.neighborGameDate('20260612'), '20260613')
+  })
+
+  it('on Eastern time pulls no neighbor', () => {
+    origGuess = moment.tz.guess
+    moment.tz.guess = () => 'America/New_York'
+    assert.equal(ESPN.neighborGameDate('20260612'), null)
+  })
+})


### PR DESCRIPTION
## Problem

Closes #210. A World Cup match that had already been played did not appear for a European viewer using `rolloverHours` + `alwaysShowToday`.

Root cause is a timezone mismatch, **not** the `rolloverHours: 24` config:

- ESPN buckets scoreboard games by **US Eastern** calendar date (`?dates=YYYYMMDD`).
- `formatScores()` filters the returned events by the **viewer's local** calendar date (`providers/ESPN.js`, `moment.tz(event.date, localTZ)`).

A match kicking off near midnight ET lands on a different *local* day than the ET day ESPN filed it under, so it is returned by **neither** the "today" nor the "yesterday" query and silently disappears.

### Concrete case from the issue

The Korea match `CZE @ KOR` has `event.date = 2026-06-12T02:00Z`. Live ESPN feed:

```
dates=20260611 -> RSA @ MEX (19:00Z),  CZE @ KOR (2026-06-12T02:00Z)
dates=20260612 -> BIH @ CAN (19:00Z),  PAR @ USA (2026-06-13T01:00Z)
```

ESPN files `CZE @ KOR` under **June 11** (22:00 ET). For a viewer in Europe (CEST, UTC+2) the kickoff is **June 12 04:00**, i.e. local "today".

| Fetch | ESPN query | Korea returned? | local-date filter | kept? |
|-------|-----------|-----------------|-------------------|-------|
| today | `dates=20260612` | no | `20260612` | absent |
| yesterday | `dates=20260611` | yes | `20260612 != 20260611` | **dropped** |

Shown nowhere.

## Fix

`getScores()` now also fetches the **single adjacent ESPN day** on the side of the viewer's UTC offset (none when the viewer is on Eastern time) and merges its events, deduped by `id`. ESPN's date buckets are disjoint, so this only adds boundary games. The existing local-date filter in `formatScores()` then keeps exactly the games for the requested local day — recovering the Korea match into "today" with no duplication into "yesterday".

Also refactors URL building and per-day fetch/normalize into `scoreboardUrl()` / `fetchScoreboardEvents()` helpers, and adds `neighborGameDate()`.

## Proof

New regression test `tests/unit/providers/ESPN.timezone.test.js` (timezone pinned to `Europe/Berlin` via `moment.tz.guess`) reproduces the exact issue scenario.

With the fix reverted, the test fails exactly as the bug describes:

```
not ok 1 - keeps a 02:00Z match that ESPN files under the previous Eastern day
  error: 'expected CZE@KOR, got ["BIH@CAN"]'
```

With the fix, the full unit suite is green:

```
# tests 110
# pass 110
# fail 0
```

`neighborGameDate()` is also unit-tested for east-of-ET (Europe -> previous day), west-of-ET (Pacific -> next day), and on-ET (no neighbor).

## Notes / trade-offs

- For viewers **not** on US Eastern time this adds one extra ESPN scoreboard request per league per poll (the adjacent day). Viewers on Eastern time are unchanged (no neighbor fetch). The neighbor request degrades gracefully — an unmatched/empty day yields no events rather than an error.
- No change to display logic or `rolloverHours` / `alwaysShowToday` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)