### PR TITLE
Send User-Agent on schedule fetches to avoid Akamai 403

### DIFF
--- a/providers/ESPN.js
+++ b/providers/ESPN.js
@@ -571,6 +571,13 @@ module.exports = {
   // Key: `${LEAGUE}:${TEAM_ABBR}`. TTL is 6 hours; schedules rarely change intraday.
   teamScheduleCache: {},
 
+  // site.api.espn.com sits behind Akamai bot protection that 403s requests
+  // with no User-Agent (Node's fetch default) and also 403s browser UAs whose
+  // TLS fingerprint doesn't match a real browser. An honest non-browser UA
+  // passes. See https://github.com/dathbe/MMM-MyScoreboard issue on upcoming
+  // games returning empty.
+  FETCH_USER_AGENT: 'MMM-MyScoreboard (+https://github.com/dathbe/MMM-MyScoreboard)',
+
   getLeaguePath: function (league) {
     return this.LEAGUE_PATHS[league]
   },
@@ -1213,7 +1220,7 @@ module.exports = {
       var url = 'https://site.api.espn.com/apis/site/v2/sports/'
         + leaguePath + '/teams/' + encodeURIComponent(team) + '/schedule'
       try {
-        var response = await fetch(url)
+        var response = await fetch(url, { headers: { 'User-Agent': this.FETCH_USER_AGENT } })
         Log.debug(`[MMM-MyScoreboard] ${url} fetched`)
         if (!response.ok) {
           self.teamScheduleCache[cacheKey] = { fetchedAt: now, nextGame: null }

--- a/tests/helpers/mock-fetch.js
+++ b/tests/helpers/mock-fetch.js
@@ -44,7 +44,9 @@ function mockFetch() {
     hitCounts.set(url, 0)
   }
 
-  globalThis.fetch = async function (input) {
+  const lastInits = new Map()
+
+  globalThis.fetch = async function (input, init) {
     const url = typeof input === 'string'
       ? input
       : input?.url ? input.url : String(input)
@@ -53,11 +55,16 @@ function mockFetch() {
       throw new Error(`mockFetch: no route for ${url}`)
     }
     hitCounts.set(url, hitCounts.get(url) + 1)
+    lastInits.set(url, init)
     return new Response(r.body, { status: r.status, headers: r.headers })
   }
 
   function hits(url) {
     return hitCounts.get(url) ?? 0
+  }
+
+  function lastInit(url) {
+    return lastInits.get(url)
   }
 
   function setError(url, err) {
@@ -67,7 +74,7 @@ function mockFetch() {
 
   // Patch fetch to honor setError routes.
   const wrapped = globalThis.fetch
-  globalThis.fetch = async function (input) {
+  globalThis.fetch = async function (input, init) {
     const url = typeof input === 'string'
       ? input
       : input?.url ? input.url : String(input)
@@ -76,14 +83,14 @@ function mockFetch() {
       hitCounts.set(url, hitCounts.get(url) + 1)
       throw r.error
     }
-    return wrapped(input)
+    return wrapped(input, init)
   }
 
   function restore() {
     globalThis.fetch = origFetch
   }
 
-  return { route, setError, hits, restore }
+  return { route, setError, hits, lastInit, restore }
 }
 
 module.exports = { mockFetch }

--- a/tests/unit/providers/ESPN.schedule.test.js
+++ b/tests/unit/providers/ESPN.schedule.test.js
@@ -316,6 +316,18 @@ describe('ESPN.getTeamSchedule', () => {
     assert.equal(ESPN.teamScheduleCache['NHL:TOR'].nextGame.hTeam, 'TOR')
   })
 
+  it('sends a non-browser User-Agent (Akamai 403s UA-less requests)', async () => {
+    const future = new Date(Date.now() + 24 * 3600 * 1000).toISOString()
+    const url = 'https://site.api.espn.com/apis/site/v2/sports/hockey/nhl/teams/TOR/schedule'
+    mock.route(url, { events: [futureEvent(future, TOR, MTL)] })
+
+    await ESPN.getTeamSchedule({ league: 'NHL', teams: ['TOR'] }, () => {})
+
+    const init = mock.lastInit(url)
+    assert.equal(init.headers['User-Agent'], ESPN.FETCH_USER_AGENT)
+    assert.match(ESPN.FETCH_USER_AGENT, /MMM-MyScoreboard/)
+  })
+
   it('second call within TTL hits cache (no second fetch)', async () => {
     const future = new Date(Date.now() + 24 * 3600 * 1000).toISOString()
     const url = 'https://site.api.espn.com/apis/site/v2/sports/hockey/nhl/teams/TOR/schedule'


### PR DESCRIPTION
## Problem

The Upcoming Games section silently renders empty for some users. The per-team schedule endpoint (`site.api.espn.com`, Akamai edge) now returns **403** for requests without a `User-Agent` header — Node's `fetch` sends none by default. Every `getTeamSchedule` call fails, the error is caught, and `null` is cached per team, so the section just shows nothing.

Notes from debugging on a Raspberry Pi:

- Requests with **no UA** → 403
- Requests with a **spoofed browser UA** → also 403 (Akamai fingerprints TLS; a Chrome UA on a Node TLS stack reads as a bot)
- Honest non-browser UAs (`curl/7.74.0`, `MMM-MyScoreboard (...)`) → 200
- Behavior varies by edge/region: the same UA-less request succeeds from one network and 403s from another, so not everyone is affected
- The scoreboard host (`site.web.api.espn.com`) is different infrastructure and unaffected — live scores keep working, which makes this failure easy to miss

## Fix

Send an honest module User-Agent on schedule fetches:

```
User-Agent: MMM-MyScoreboard (+https://github.com/dathbe/MMM-MyScoreboard)
```

Also extends the fetch mock to record request init (fixing an unrelated latent bug where the `setError` wrapper dropped the init argument) and adds a regression test asserting the header is sent.

## Testing

- 114 unit tests pass, curated e2e suite passes
- Verified live on a Pi that previously 403'd: schedule fetch returns 200 and the Upcoming Games section renders again

🤖 Generated with [Claude Code](https://claude.com/claude-code)