### PR TITLE
Add followed-team game event notifications

### DIFF
--- a/MMM-MyScoreboard.js
+++ b/MMM-MyScoreboard.js
@@ -38,6 +38,10 @@ Module.register('MMM-MyScoreboard', {
     baseballDetailInterval: 15,
     baseballDetailViewOverride: true,
     showScoreAnimation: false,
+    gameEventNotifications: {
+      enabled: false,
+      events: ['game.started', 'game.halftime', 'game.final'],
+    },
     showUpcomingGames: false,
     sports: [
       {
@@ -981,9 +985,9 @@ Module.register('MMM-MyScoreboard', {
       var oldData = this.sportsData[payload.label]
       var dataChanged = !oldData || JSON.stringify(oldData.scores) !== JSON.stringify(newData.scores)
 
-      // Detect score changes for animations
-      if (this.config.showScoreAnimation && oldData && oldData.scores && dataChanged) {
-        this.detectScoreChanges(payload.label, oldData.scores, payload.scores)
+      // Detect followed-team changes for animations and optional broadcasts
+      if ((this.config.showScoreAnimation || this.gameEventNotificationsEnabled()) && oldData && oldData.scores && dataChanged) {
+        this.detectScoreChanges(payload.label, oldData.scores, payload.scores, payload.index)
       }
 
       this.sportsData[payload.label] = newData
@@ -1202,7 +1206,46 @@ Module.register('MMM-MyScoreboard', {
     })
   },
 
-  detectScoreChanges: function (label, oldScores, newScores) {
+  gameEventNotificationsEnabled: function () {
+    return this.config.gameEventNotifications
+      && this.config.gameEventNotifications.enabled === true
+      && Array.isArray(this.config.gameEventNotifications.events)
+  },
+
+  gameEventEnabled: function (event) {
+    return this.gameEventNotificationsEnabled()
+      && this.config.gameEventNotifications.events.includes(event)
+  },
+
+  gameStatusText: function (game) {
+    return Array.isArray(game.status) ? game.status.join(' ') : String(game.status || '')
+  },
+
+  sendGameEvent: function (event, league, label, game, followedTeams, extra) {
+    if (!this.gameEventEnabled(event)) return
+
+    this.sendNotification('MYSCOREBOARD_GAME_EVENT', Object.assign({
+      event: event,
+      league: league || label,
+      label: label,
+      gameId: game.gameId || (league || label) + ':' + game.vTeam + '@' + game.hTeam,
+      timestamp: Date.now(),
+      home: {
+        name: game.hTeamLong || game.hTeam,
+        abbreviation: game.hTeam,
+        score: game.hScore,
+      },
+      away: {
+        name: game.vTeamLong || game.vTeam,
+        abbreviation: game.vTeam,
+        score: game.vScore,
+      },
+      followedTeams: followedTeams,
+      status: this.gameStatusText(game),
+    }, extra || {}))
+  },
+
+  detectScoreChanges: function (label, oldScores, newScores, league) {
     var followed = this.followedTeams[label]
     if (!followed) return
 
@@ -1221,28 +1264,56 @@ Module.register('MMM-MyScoreboard', {
       var gameKey = label + ':' + newGame.vTeam + '@' + newGame.hTeam
       var hIsFollowed = followed.includes(newGame.hTeam)
       var vIsFollowed = followed.includes(newGame.vTeam)
+      var followedInGame = followed.filter(function (team) {
+        return team === newGame.hTeam || team === newGame.vTeam
+      })
+      var newStatus = this.gameStatusText(newGame)
+      var oldStatus = this.gameStatusText(oldGame)
+
+      if (followedInGame.length === 0) continue
+
+      // Broadcast a followed team's game starting.
+      if (newGame.gameMode === this.gameModes.IN_PROGRESS
+        && oldGame.gameMode === this.gameModes.SCHEDULED
+        && !/half[ -]?time/i.test(newStatus)) {
+        this.sendGameEvent('game.started', league, label, newGame, followedInGame)
+      }
+
+      // Broadcast halftime once when the provider status first enters halftime.
+      if (/half[ -]?time/i.test(newStatus) && !/half[ -]?time/i.test(oldStatus)) {
+        this.sendGameEvent('game.halftime', league, label, newGame, followedInGame, { checkpoint: 'halftime' })
+      }
 
       // Check if followed team scored
-      if (hIsFollowed && newGame.hScore > oldGame.hScore) {
-        this.scoreAnimations[gameKey] = { type: 'score', team: 'home' }
-        this.animationBlockUntil = Math.max(this.animationBlockUntil, Date.now() + 4000)
+      if (newGame.gameMode !== this.gameModes.FINAL && hIsFollowed && newGame.hScore > oldGame.hScore) {
+        if (this.config.showScoreAnimation) {
+          this.scoreAnimations[gameKey] = { type: 'score', team: 'home' }
+          this.animationBlockUntil = Math.max(this.animationBlockUntil, Date.now() + 4000)
+        }
+        this.sendGameEvent('game.score', league, label, newGame, followedInGame, { scoringTeam: newGame.hTeam })
       }
-      else if (vIsFollowed && newGame.vScore > oldGame.vScore) {
-        this.scoreAnimations[gameKey] = { type: 'score', team: 'visitor' }
-        this.animationBlockUntil = Math.max(this.animationBlockUntil, Date.now() + 4000)
+      else if (newGame.gameMode !== this.gameModes.FINAL && vIsFollowed && newGame.vScore > oldGame.vScore) {
+        if (this.config.showScoreAnimation) {
+          this.scoreAnimations[gameKey] = { type: 'score', team: 'visitor' }
+          this.animationBlockUntil = Math.max(this.animationBlockUntil, Date.now() + 4000)
+        }
+        this.sendGameEvent('game.score', league, label, newGame, followedInGame, { scoringTeam: newGame.vTeam })
       }
 
-      // Check if game just ended and followed team won
+      // Check if game just ended.
       if (newGame.gameMode === this.gameModes.FINAL && oldGame.gameMode !== this.gameModes.FINAL) {
         var followedWon = (hIsFollowed && newGame.hScore > newGame.vScore)
           || (vIsFollowed && newGame.vScore > newGame.hScore)
-        if (followedWon) {
+        if (followedWon && this.config.showScoreAnimation) {
           this.scoreAnimations[gameKey] = { type: 'win' }
           // winGlow CSS animation runs 8s; hold off any non-animation DOM
           // rebuild (e.g. the upcoming-games update that often arrives just
           // after a final) until it has visibly finished.
           this.animationBlockUntil = Math.max(this.animationBlockUntil, Date.now() + 8500)
         }
+        this.sendGameEvent('game.final', league, label, newGame, followedInGame, {
+          result: newGame.hScore === newGame.vScore ? 'tie' : (followedWon ? 'win' : 'loss'),
+        })
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Add MMM-MyScoreboard module to the `modules` array in the `config/config.js` fil
 | `showBaseballDetail`   | When set to `true`, in-progress baseball games (MLB, NCAAB, WBC) display the current game situation: base runners on a diamond indicator, ball-strike count, outs, and the current pitcher/batter matchup. Pitcher and batter are hidden between half-innings.<br><br>**Type** `Boolean`<br>**Default** `false`
 | `baseballDetailInterval` | When `showBaseballDetail` is enabled and a baseball game is in-progress, the module polls for score updates at this interval (in seconds) instead of the default 2-minute interval. Only baseball leagues are polled at this faster rate.<br><br>**Type** `Number`<br>**Default** `15` (seconds, minimum `1`)
 | `showScoreAnimation`   | When set to `true`, a firework animation plays on the score element whenever a followed team scores. The animation type varies by sport: low-scoring sports (MLB, NFL, NHL, soccer) get a firework burst, high-scoring sports (NBA, college basketball) get a quick flash, and an extended celebration with multiple staggered fireworks plays when a followed team wins.<br><br>**Type** `Boolean`<br>**Default** `false`
+| `gameEventNotifications` | Optionally broadcasts selected milestones for followed teams as the global MagicMirror notification `MYSCOREBOARD_GAME_EVENT`. See [Game Event Notifications](#game-event-notifications).<br><br>**Type** `Object`<br>**Default** `{ enabled: false, events: ['game.started', 'game.halftime', 'game.final'] }`
 | `showUpcomingGames`    | When set to `true`, adds an "Upcoming" section below each sport for every followed team whose today slate is either empty or fully final (MLB doubleheaders are handled — both games must be final). Each row shows the team's next scheduled game with its date and start time, pulled once per team from the league's schedule endpoint and cached for 6 hours. Only applies to followed teams (the `teams` array in a sport config) and only for ESPN-backed leagues (MLB, NFL, NBA, NHL, NCAAF, NCAAM, MLS, most soccer). Non-ESPN providers (CPL, PWHL, SNET) are skipped.<br><br>**Type** `Boolean`<br>**Default** `false`
 
 #### Baseball Detail Example
@@ -112,6 +113,47 @@ Add MMM-MyScoreboard module to the `modules` array in the `config/config.js` fil
 #### Upcoming Games Example
 
 ![Upcoming Games](upcomingGamesExample.png)
+
+### Game Event Notifications
+
+MMM-MyScoreboard can optionally broadcast game milestones for followed teams so other MagicMirror modules can present or act on them. The feature is disabled by default and does not change the scoreboard display.
+
+```js
+gameEventNotifications: {
+  enabled: true,
+  events: ['game.started', 'game.halftime', 'game.final'],
+}
+```
+
+Supported events are:
+
+| Event | When it is sent |
+|-------|-----------------|
+| `game.started` | A followed team's game moves from scheduled to in progress. |
+| `game.halftime` | A followed team's game first enters halftime, when the provider supplies a halftime status. |
+| `game.final` | A followed team's game first becomes final. |
+| `game.score` | A followed team's score increases. This is opt-in because it can be noisy in high-scoring sports. |
+
+Events are sent as the global MagicMirror notification `MYSCOREBOARD_GAME_EVENT`. The first update after startup establishes a baseline and does not emit an event.
+
+Example payload:
+
+```js
+{
+  event: 'game.final',
+  league: 'NHL',
+  label: 'Hockey',
+  gameId: 'NHL:MTL@TOR',
+  timestamp: 1772949600000,
+  home: { name: 'Toronto Maple Leafs', abbreviation: 'TOR', score: 3 },
+  away: { name: 'Montreal Canadiens', abbreviation: 'MTL', score: 1 },
+  followedTeams: ['TOR'],
+  status: 'Final',
+  result: 'win',
+}
+```
+
+`game.halftime` also includes `checkpoint: 'halftime'`; `game.score` includes `scoringTeam`. Consumers should use `event` as the discriminator and ignore fields they do not need.
 
 ### Configuring Your "Sports" List
 

--- a/tests/helpers/load-frontend.js
+++ b/tests/helpers/load-frontend.js
@@ -69,6 +69,7 @@ function makeInstance(def, init = {}) {
     noGamesToday: init.noGamesToday ?? {},
     scoreAnimations: init.scoreAnimations ?? {},
     sentNotifications: [],
+    broadcastNotifications: [],
     domUpdated: 0,
   })
 
@@ -76,6 +77,12 @@ function makeInstance(def, init = {}) {
     instance.sentNotifications.push({ notification, payload })
     if (typeof init.onSendSocket === 'function') {
       init.onSendSocket(notification, payload)
+    }
+  }
+  instance.sendNotification = function (notification, payload) {
+    instance.broadcastNotifications.push({ notification, payload })
+    if (typeof init.onSend === 'function') {
+      init.onSend(notification, payload)
     }
   }
   instance.updateDom = function () {

--- a/tests/unit/frontend/detectScoreChanges.test.js
+++ b/tests/unit/frontend/detectScoreChanges.test.js
@@ -25,6 +25,7 @@ function game(opts) {
 describe('detectScoreChanges', () => {
   function setup() {
     const inst = makeInstance(def, {
+      config: { showScoreAnimation: true },
       followedTeams: { NHL: ['TOR'] },
     })
     inst.gameModes = gameModes
@@ -118,5 +119,124 @@ describe('detectScoreChanges', () => {
       [],
       [game({ h: 'TOR', v: 'MTL', hScore: 1, vScore: 0, gameMode: 1 })])
     assert.equal(Object.keys(inst.scoreAnimations).length, 0)
+  })
+
+  it('broadcasts no events by default', () => {
+    const inst = setup()
+    inst.detectScoreChanges('NHL',
+      [game({ h: 'TOR', v: 'MTL', hScore: 3, vScore: 1, gameMode: 1 })],
+      [game({ h: 'TOR', v: 'MTL', hScore: 3, vScore: 1, gameMode: 2 })],
+      'NHL')
+    assert.deepEqual(inst.broadcastNotifications, [])
+  })
+
+  it('broadcasts a neutral final event for a followed team', () => {
+    const inst = setup()
+    inst.config.gameEventNotifications = { enabled: true, events: ['game.final'] }
+    const oldGame = game({ h: 'TOR', v: 'MTL', hScore: 3, vScore: 1, gameMode: 1 })
+    const newGame = Object.assign(
+      game({ h: 'TOR', v: 'MTL', hScore: 3, vScore: 1, gameMode: 2 }),
+      { hTeamLong: 'Toronto Maple Leafs', vTeamLong: 'Montreal Canadiens', status: ['Final'] },
+    )
+    inst.followedTeams.Hockey = ['TOR']
+
+    inst.detectScoreChanges('Hockey', [oldGame], [newGame], 'NHL')
+
+    assert.equal(inst.broadcastNotifications.length, 1)
+    assert.equal(inst.broadcastNotifications[0].notification, 'MYSCOREBOARD_GAME_EVENT')
+    assert.deepEqual(inst.broadcastNotifications[0].payload, {
+      event: 'game.final',
+      league: 'NHL',
+      label: 'Hockey',
+      gameId: 'NHL:MTL@TOR',
+      timestamp: inst.broadcastNotifications[0].payload.timestamp,
+      home: { name: 'Toronto Maple Leafs', abbreviation: 'TOR', score: 3 },
+      away: { name: 'Montreal Canadiens', abbreviation: 'MTL', score: 1 },
+      followedTeams: ['TOR'],
+      status: 'Final',
+      result: 'win',
+    })
+  })
+
+  it('broadcasts when a followed team game starts', () => {
+    const inst = setup()
+    inst.config.showScoreAnimation = false
+    inst.config.gameEventNotifications = { enabled: true, events: ['game.started'] }
+
+    inst.detectScoreChanges('NHL',
+      [game({ h: 'TOR', v: 'MTL', hScore: 0, vScore: 0, gameMode: 0 })],
+      [game({ h: 'TOR', v: 'MTL', hScore: 0, vScore: 0, gameMode: 1 })],
+      'NHL')
+
+    assert.equal(inst.broadcastNotifications.length, 1)
+    assert.equal(inst.broadcastNotifications[0].payload.event, 'game.started')
+  })
+
+  it('broadcasts halftime once without broadcasting every score', () => {
+    const inst = setup()
+    inst.config.showScoreAnimation = false
+    inst.config.gameEventNotifications = { enabled: true, events: ['game.halftime'] }
+    const oldGame = Object.assign(
+      game({ h: 'TOR', v: 'MTL', hScore: 48, vScore: 44, gameMode: 1 }),
+      { status: ['2nd 0:02'] },
+    )
+    const halftime = Object.assign(
+      game({ h: 'TOR', v: 'MTL', hScore: 50, vScore: 44, gameMode: 1 }),
+      { status: ['Halftime'] },
+    )
+
+    inst.detectScoreChanges('NHL', [oldGame], [halftime], 'NBA')
+    inst.detectScoreChanges('NHL', [halftime], [halftime], 'NBA')
+
+    assert.equal(inst.broadcastNotifications.length, 1)
+    assert.equal(inst.broadcastNotifications[0].payload.event, 'game.halftime')
+    assert.equal(inst.broadcastNotifications[0].payload.checkpoint, 'halftime')
+  })
+
+  it('supports opt-in score events for low-scoring sports', () => {
+    const inst = setup()
+    inst.config.showScoreAnimation = false
+    inst.config.gameEventNotifications = { enabled: true, events: ['game.score'] }
+
+    inst.detectScoreChanges('NHL',
+      [game({ h: 'TOR', v: 'MTL', hScore: 0, vScore: 0, gameMode: 1 })],
+      [game({ h: 'TOR', v: 'MTL', hScore: 1, vScore: 0, gameMode: 1 })],
+      'NHL')
+
+    assert.equal(inst.broadcastNotifications.length, 1)
+    assert.equal(inst.broadcastNotifications[0].payload.event, 'game.score')
+    assert.equal(inst.broadcastNotifications[0].payload.scoringTeam, 'TOR')
+  })
+
+  it('detects broadcasts from score updates when animations are disabled', () => {
+    const inst = makeInstance(def, {
+      identifier: 'scoreboard-1',
+      config: {
+        rolloverHours: 24,
+        showScoreAnimation: false,
+        gameEventNotifications: { enabled: true, events: ['game.final'] },
+      },
+      followedTeams: { NHL: ['TOR'] },
+      sportsData: {
+        NHL: {
+          scores: [game({ h: 'TOR', v: 'MTL', hScore: 3, vScore: 1, gameMode: 1 })],
+          league: 'NHL',
+          sortIdx: 0,
+        },
+      },
+    })
+    inst.gameModes = gameModes
+
+    inst.socketNotificationReceived('MMM-MYSCOREBOARD-SCORE-UPDATE', {
+      instanceId: 'scoreboard-1',
+      label: 'NHL',
+      index: 'NHL',
+      sortIdx: 0,
+      scores: [game({ h: 'TOR', v: 'MTL', hScore: 3, vScore: 1, gameMode: 2 })],
+    })
+
+    assert.equal(inst.broadcastNotifications.length, 1)
+    assert.equal(inst.broadcastNotifications[0].payload.event, 'game.final')
+    assert.deepEqual(inst.scoreAnimations, {})
   })
 })


### PR DESCRIPTION
## Summary

- add an opt-in `MYSCOREBOARD_GAME_EVENT` notification for followed-team milestones
- support game start, halftime, final, and optional score events
- keep the first update as a silent baseline and preserve existing score-animation behavior
- document configuration, event semantics, and the neutral payload

The feature is disabled by default. `game.score` is not in the default event list because it can be noisy in high-scoring sports.

## Testing

- `npm run lint`
- 119 unit tests passed using the repository test files
- browser matrix was attempted, but this standalone checkout did not contain the bootstrapped MagicMirror test installation required by the harness; upstream CI can run that environment-specific suite